### PR TITLE
to add template instructions

### DIFF
--- a/spec-tooling-guides.md
+++ b/spec-tooling-guides.md
@@ -19,7 +19,7 @@ The tools recommended by DIF are:
 1. **[SpecUp](https://github.com/decentralized-identity/spec-up)** is a
    lightweight markdown generator similar to Jekyll, which is itself hosted and
    maintained as a standing DIF work item. 
-   - Work items intending to use spec-up for their deliverables should request a
+   - Work items intending to use Spec-up for their deliverables should request a
      "spec-up repo" from DIF at time of beginning work, i.e., a repo cloned from
      the [SpecUp repo
      template](https://github.com/decentralized-identity/spec-up)
@@ -45,7 +45,12 @@ The tools recommended by DIF are:
      fork](https://github.com/decentralized-identity/template-IETF-bound) of the
      `internet-draft-template` by Martin Thomson (a long-time IETF WG chair). It
      contains a dockerized version of `markdown2rfc` and automations for github
-     that can be customized (documentation forthcoming). 
+     that can be customized (documentation forthcoming). If these cannot be
+     housed in the DIF org, they need to clearly state in README.md and
+     CONTRIBUTING.md that it is an ongoing DIF work item that only accepts 
+     substantial contributions from DIF members in the WG. Tagging the repo with
+     the appropriate tag (i.e. `wg-cc`) helps them be displayed on the WG's   
+     webpage on the DIF website and generally assists discoverability/visibility.
    - Note: It is also possible to generate IETF RFCs from markdown files using
         [BikeShed](https://tabatkins.github.io/bikeshed/) in situations where
    user-friendlier tools lack flexibility.

--- a/spec-tooling-guides.md
+++ b/spec-tooling-guides.md
@@ -12,13 +12,17 @@ item can come to a consensus *up front* about an SDO that it wants to target
 from the beginning, we advise the group to work within the format and tooling
 preferences of that SDO from the begining.  If no clear SDO can be agreed to
 upfront, or if a "DIF-terminal" specification is consensual from the beginning,
-we recommend SpecUp, a markdown-based tool fit-for-purpose and designed by DIF's
-founding executive director.
+we recommend SpecUp, a markdown-based tool maintained as a standing work item of
+the DIF technical steering committee.
 
 The tools recommended by DIF are:
 1. **[SpecUp](https://github.com/decentralized-identity/spec-up)** is a
    lightweight markdown generator similar to Jekyll, which is itself hosted and
    maintained as a standing DIF work item. 
+   - Work items intending to use spec-up for their deliverables should request a
+     "spec-up repo" from DIF at time of beginning work, i.e., a repo cloned from
+     the [SpecUp repo
+     template](https://github.com/decentralized-identity/spec-up)
 2. **[BikeShed](https://tabatkins.github.io/bikeshed/)** is a general-purposes
    specification authoring tool with many features and settings, which may be a
    bit overwhelming for more junior/inexperienced audiences.
@@ -34,8 +38,16 @@ The tools recommended by DIF are:
    tool for IETF RFCs, but may require a bit of XML familiarity; the dockerized
    version, [`markdown2rfc`](https://github.com/oauthstuff/markdown2rfc), also
    contains the similar go-based tool, `mmark`, can be a more user-friendly
-   experience. It is also possible to generate IETF RFCs from markdown files
-   using [BikeShed](https://tabatkins.github.io/bikeshed/) in situations where
+   experience.
+   - Unless editors have prior experience with IETF spec tooling, we recommend
+     work items intended as IETF internet drafts start work in a DIF repo cloned
+     from the [DIF
+     fork](https://github.com/decentralized-identity/template-IETF-bound) of the
+     `internet-draft-template` by Martin Thomson (a long-time IETF WG chair). It
+     contains a dockerized version of `markdown2rfc` and automations for github
+     that can be customized (documentation forthcoming). 
+   - Note: It is also possible to generate IETF RFCs from markdown files using
+        [BikeShed](https://tabatkins.github.io/bikeshed/) in situations where
    user-friendlier tools lack flexibility.
 
 ## Educational materials

--- a/spec-tooling-guides.md
+++ b/spec-tooling-guides.md
@@ -45,12 +45,14 @@ The tools recommended by DIF are:
      fork](https://github.com/decentralized-identity/template-IETF-bound) of the
      `internet-draft-template` by Martin Thomson (a long-time IETF WG chair). It
      contains a dockerized version of `markdown2rfc` and automations for github
-     that can be customized (documentation forthcoming). If these cannot be
-     housed in the DIF org, they need to clearly state in README.md and
-     CONTRIBUTING.md that it is an ongoing DIF work item that only accepts 
-     substantial contributions from DIF members in the WG. Tagging the repo with
-     the appropriate tag (i.e. `wg-cc`) helps them be displayed on the WG's   
-     webpage on the DIF website and generally assists discoverability/visibility.
+     that can be customized (documentation forthcoming). If for IETF acceptance
+     reasons (or for other SDO-target reasons), a repo needs to be housed outside
+     the DIF github org, it should be clearly stated in the README.md and
+     CONTRIBUTING.md at time of inception that the repo contains an ongoing DIF 
+     work item that only accepts substantial contributions from DIF members in 
+     the WG. Tagging the repo with the appropriate tag (i.e. `wg-cc`) helps them 
+     be displayed on the WG's webpage on the DIF website and generally assists 
+     discoverability & visibility.
    - Note: It is also possible to generate IETF RFCs from markdown files using
         [BikeShed](https://tabatkins.github.io/bikeshed/) in situations where
    user-friendlier tools lack flexibility.

--- a/spec-tooling-guides.md
+++ b/spec-tooling-guides.md
@@ -40,7 +40,7 @@ The tools recommended by DIF are:
    contains the similar go-based tool, `mmark`, can be a more user-friendly
    experience.
    - Unless editors have prior experience with IETF spec tooling, we recommend
-     work items intended as IETF internet drafts start work in a DIF repo cloned
+     work items intended as IETF internet drafts start work in a repository cloned
      from the [DIF
      fork](https://github.com/decentralized-identity/template-IETF-bound) of the
      `internet-draft-template` by Martin Thomson (a long-time IETF WG chair). It

--- a/spec-tooling-guides.md
+++ b/spec-tooling-guides.md
@@ -20,8 +20,8 @@ The tools recommended by DIF are:
    lightweight markdown generator similar to Jekyll, which is itself hosted and
    maintained as a standing DIF work item. 
    - Work items intending to use Spec-up for their deliverables should request a
-     "spec-up repo" from DIF at time of beginning work, i.e., a repo cloned from
-     the [SpecUp repo
+     "spec-up repo" from DIF at time of beginning work, i.e., a repo generated 
+     from the [SpecUp repo
      template](https://github.com/decentralized-identity/spec-up)
 2. **[BikeShed](https://tabatkins.github.io/bikeshed/)** is a general-purposes
    specification authoring tool with many features and settings, which may be a
@@ -40,8 +40,8 @@ The tools recommended by DIF are:
    contains the similar go-based tool, `mmark`, can be a more user-friendly
    experience.
    - Unless editors have prior experience with IETF spec tooling, we recommend
-     work items intended as IETF internet drafts start work in a repository cloned
-     from the [DIF
+     work items intended as IETF internet drafts start work in a repository 
+     generated from the [DIF
      fork](https://github.com/decentralized-identity/template-IETF-bound) of the
      `internet-draft-template` by Martin Thomson (a long-time IETF WG chair). It
      contains a dockerized version of `markdown2rfc` and automations for github


### PR DESCRIPTION
@ChrisLP, this make sense to you? @tplooker, PRs into the template repo would be warmly welcome, whether they be examples, automation tweaks, or just a little "for dummies" text in the root readme to orient first-timers.  Only editors of a work item can create branches, so "re-render on push to any branch" is probably a sane default, to prevent every single one-line PR from rerendering the previews.