### PR TITLE
Update chair_cheat_sheet.md

### DIFF
--- a/chair_cheat_sheet.md
+++ b/chair_cheat_sheet.md
@@ -40,7 +40,10 @@ The responsibilites of a DIF group chair include:
     - http://bit.ly/dif_wg_participation |
 - ### GitHub WG teams
     - Invite GitHub contributors to the Github team according to signed WG charter
-    - https://github.com/orgs/decentralized-identity/teams |
+    - https://github.com/orgs/decentralized-identity/teams
+- ### WG Training Video and Presentation
+    - [Working group training recording (Sept 2023)](https://drive.google.com/file/d/1PIsF1xQ5i1NPp_RG2A39NEfh6ck95HQg/view?usp=drive_link) 
+    - [Working group training slides](https://docs.google.com/presentation/d/1I0B3dQLQa51uCV3VFXHLsbzmyB_jZMl4/edit?usp=sharing&ouid=116182654223161791531&rtpof=true&sd=true)
 
 ### Tools and tips for Open Group Chairs:
 

--- a/chair_cheat_sheet.md
+++ b/chair_cheat_sheet.md
@@ -56,7 +56,7 @@ The responsibilites of a DIF group chair include:
 ### Tools and tips for all Chairs:
 
 - ### Claim host in zoom
-    - 212121
+- Ask ED or get access to password manager for code
     - Claim host on both accounts
     - This is often needed to allow screen-sharing for participants
 - ### Recordings

--- a/chair_cheat_sheet.md
+++ b/chair_cheat_sheet.md
@@ -1,10 +1,10 @@
-# WG chair (Quick Reference)
+# Chair Quick Reference
 
 This page is designed as a central resource hub for DIF chairs. It will be kept up-to-date with useful links and information, official DIF processes and tooling.
 
-### WG Chair Duties:
+### Chair Duties:
 
-The responsibilites of a DIF Working Group chair include:
+The responsibilites of a DIF group chair include:
 - Ensuring compliance with all DIF rules applicable to the group.
 - Organizing the smooth operation of the group, scheduling and, where neccessary, cancelling meetings.
 - Driving inclusivity, setting a positive and productive tone.
@@ -12,35 +12,16 @@ The responsibilites of a DIF Working Group chair include:
 - Developing, communicating an agenda and leading the meetings.
   - Inviting guests and publicising guest appearances (it's good form to disclosure business relations with guests in both introductions and in public advance promotion of guest appearances)
 - Attendance lists are optional, but chairs should invite new members to introduce themselves to the group.
-- Overseeing note-taking for the WG meetings
-  - Notes are used to summarize the important topics and points discussed during the meetings, a full transcript is not neccessary.
-  - Notes are used by DIF for the Newsletter and for the All-hands meeting to update the broader community.
-  - Notes are useful to discover historical meetings where certain topics were discussed.
-  - Notes are often used by the wider community to follow progress on work items.
-  - Notes also archive links, files etc. from the chat to make them accessible after the meeting.
+- Overseeing note-taking for the group meetings
 - Being a liaison between the group and all groups (both at DIF and externally) with which the group is coordinating.
 - Engaging with media, performing outreach, and ensuring the transparent operation of the group.
 - Sharing monthly updates for the DIF newsletter to inform the community
 - Engagement with activity on GitHub, responding to PRs and Issues.
-- Ensuring comformance with DIF's and the groups IPR agreements.
+- Ensuring conformance with the group's IPR agreements.
 
- 
- 
- 
-### WG Chair tools and tips:
 
-- ### Claim host in zoom
-    - 212121
-    - Claim host on both accounts
-    - This is often needed to allow screen-sharing for participants
-- ### Recordings
-    - A list of all DIF recordings.
-    - Recordings are broken down by WG using TABS at the bottom
-    - http://bit.ly/DIF_recordings_list
-- ### Send the agenda before the meeting via email/slack
-    - Please share an agenda before the meeting
-    - Link to agenda can be reshared in meeting chat 
-    - Link to agenda should also be available in the calendar entry and from the DIF WG webpage
+### Tools and tips for Working Group Chairs:
+
 - ### New member onboarding 
     - Any company or individual who is interested in joining DIF to contribute MUST first sign one of the legal forms of affiliation (Associate, Contributor, Feedback Agreement) according to their status and budget. Once they finalize this document all necessary information will be forwarded to them via a welcome email, including the WG charters etc. 
         - Associate member - paid dif member. Any company over 1000 employees can only choose this option.
@@ -60,18 +41,37 @@ The responsibilites of a DIF Working Group chair include:
 - ### GitHub WG teams
     - Invite GitHub contributors to the Github team according to signed WG charter
     - https://github.com/orgs/decentralized-identity/teams |
+
+### Tools and tips for Open Group Chairs:
+
 - ### Joining non-working groups
     - DIF has a set of non-WG "Open Groups" that can be found on the website in the "groups" menu
     - These groups can be joined without signing anything as there is no specific IPR protection
     - http://identity.foundation/
-- ### WG work items (GitHub)
-    - Use DIF's website to navigate between WG repos by opening up the working group's sub-page.
-    - https://identity.foundation/#wgs
+ 
+      
+### Tools and tips for all Chairs:
+
+- ### Claim host in zoom
+    - 212121
+    - Claim host on both accounts
+    - This is often needed to allow screen-sharing for participants
+- ### Recordings
+    - A list of all DIF recordings.
+    - Recordings are broken down by group using TABS at the bottom
+    - http://bit.ly/DIF_recordings_list
+- ### Send the agenda before the meeting via email/slack/discord
+    - Please share an agenda before the meeting
+    - Link to agenda can be reshared in meeting chat 
+    - Link to agenda should also be available in the calendar entry and from the DIF group webpage
+- ### Work items (GitHub)
+    - Use DIF's website to navigate between repos by opening up the working group's sub-page.
+    - https://identity.foundation/working-groups/
 - ### Spec writing tool
     - DIF recommends two different tools for writing specifications: SpecUP, ReSpec 
     - https://github.com/decentralized-identity/org/blob/master/spec-tooling-guides.md 
 - ### Mailing list(s)
-    - Join the main mailing list and find WG/topic relevant mailing lists in sub-categories
+    - Join the main mailing list and find group/topic relevant mailing lists in sub-categories
     - Please use corporate email address when joining the list. Please use full name when registering.
     -  https://dif.groups.io/g/main 
 - ### Slack 
@@ -84,7 +84,7 @@ The responsibilites of a DIF Working Group chair include:
     - http://bit.ly/dif-calendar
 - ### Brand Guidelines
     - DIF is often represented in online/in-person settings, materials and information is collected here
-    -  http://bit.ly/DIF_brand_guidelines
+    - http://bit.ly/DIF_brand_guidelines
 - ### Presentation Template 
     - A template to create presentations at DIF
     -  [Template](https://docs.google.com/presentation/d/1jXF5LhBLmKsbjCfGGBFNDC_tqISmgd8-DK-ISxSQkwc/edit#slide=id.g7760498cf3_0_50)
@@ -101,7 +101,7 @@ The responsibilites of a DIF Working Group chair include:
     - If a DIF wg chair steps down, the WG can nominate new chairs. The preferred method for electing the new chair is via consensus. If there is no consensus within the group then voting must be organized - rules for the voting process are in DIF's charter. 
     - A chair can not replace her/himself with a colleague. A nomination must take place and the group should follow consensus/voting process. 
     - As DIF is a place for collaboration, acknowledging work funded or done by others is a gesture to recognize the efforts behind ratified work items. Consider creating a section for acknowledgments and recognize specific grants, people, or organizations whose work is invaluable for the delivered work item. 
--  ### Updating WG page 
+-  ### Updating group page 
     - The website uses templates and content is rendered accordingly. For major changes, please reach out to operations.
     -  __Update via github:__
         -  Use the [templates/pages/working-groups/](https://github.com/decentralized-identity/decentralized-identity.github.io/tree/master/templates/pages/working-groups) of the DIF website repo.


### PR DESCRIPTION
Small fixes and updates to generalize for all group types

- Edits for typos and brevity
- Slight reorganization and edits to clarify which are relevant to Open Groups vs Working Groups

There are some items I'm not completely sure about w.r.t Open Groups vs Working Groups, so I can follow up with a subsequent PR, e.g. "If a DIF wg chair steps down, the WG can nominate new chairs. The preferred method for electing the new chair is via consensus. If there is no consensus within the group then voting must be organized - rules for the voting process are in DIF's charter. "

Also, this link https://identity.foundation/#wgs isn't valid; it should be https://identity.foundation/working-groups/. At the same time, that's currently going to the Events page. I'll create a separate issue there
