### PR TITLE
General information about starting a group at DIF

### DIFF
--- a/start_a_group.md
+++ b/start_a_group.md
@@ -8,9 +8,7 @@ First, decide which group type is appropriate for your needs:
 - Special Interest Group: Open group serving as a cooperative space to align on common areas of interest and encourage ideation
 - User Group: Open group consisting of users interested in a DIF codebase
 
-It's also possible that your idea can be accomplished as a work item in an existing group. 
-
-See [Participation](https://github.com/decentralized-identity/org/blob/master/dif_org_faq.md#participation) for more details.
+It's also possible that your idea can be accomplished as a work item in an existing group. See [Participation](https://github.com/decentralized-identity/org/blob/master/dif_org_faq.md#participation) for more details. 
 
 ## Fill out and submit a charter proposal
 1. Select the appropriate charter template from [TODO: insert link after PR merged] and make a copy so you can edit it.
@@ -25,3 +23,5 @@ After approval, DIF staff will contact you requesting the final information need
 
 ## Group launch
 Your group is now ready to be launched. DIF staff will coordinate with you as needed.
+
+See [Working Group Lifecycle](https://github.com/decentralized-identity/org/blob/master/working-group-lifecycle.md) for additional context.

--- a/start_a_group.md
+++ b/start_a_group.md
@@ -19,7 +19,7 @@ It's also possible that your idea can be accomplished as a work item in an exist
 DIF staff will work with the steering committee to get approval, and will contact you if there are any questions. 
 
 ## Provide information needed for launching the group
-After approval, DIF staff will contact you requesting the final information needed to set up the group. Fill out this information and return it to DIF.
+After approval, DIF staff will contact you requesting the final information needed to set up the group. Copy and fill out [this form template](https://docs.google.com/document/d/16L5qhVky6DCf3-0y5_EooAGdpNPlpMi5STKA0KIgHfA/edit#heading=h.qcn49g1ayebb) and return it to DIF.
 
 ## Group launch
 Your group is now ready to be launched. DIF staff will coordinate with you as needed.

--- a/start_a_group.md
+++ b/start_a_group.md
@@ -11,7 +11,7 @@ First, decide which group type is appropriate for your needs:
 It's also possible that your idea can be accomplished as a work item in an existing group. See [Participation](https://github.com/decentralized-identity/org/blob/master/dif_org_faq.md#participation) for more details. 
 
 ## Fill out and submit a charter proposal
-1. Select the appropriate charter template from [TODO: insert link after PR merged] and make a copy so you can edit it.
+1. Select the appropriate template from [DIF's Charter Templates](https://github.com/decentralized-identity/org/blob/master/README.md#dif-group-charter-templates) and make a copy so you can edit it.
 2. Fill out the proposal
 3. Email to community@identity.foundation
 

--- a/start_a_group.md
+++ b/start_a_group.md
@@ -1,0 +1,27 @@
+# Starting a group at DIF
+
+Contact: community@identity.foundation
+
+## Decide the group type
+First, decide which group type is appropriate for your needs:
+- Working Group: IPR-protected group that produces technical specifications or other artifacts. Participants must be DIF members.
+- Special Interest Group: Open group serving as a cooperative space to align on common areas of interest and encourage ideation
+- User Group: Open group consisting of users interested in a DIF codebase
+
+It's also possible that your idea can be accomplished as a work item in an existing group. 
+
+See [Participation](https://github.com/decentralized-identity/org/blob/master/dif_org_faq.md#participation) for more details.
+
+## Fill out and submit a charter proposal
+1. Select the appropriate charter template from [TODO: insert link after PR merged] and make a copy so you can edit it.
+2. Fill out the proposal
+3. Email to community@identity.foundation
+
+## DIF approval
+DIF staff will work with the steering committee to get approval, and will contact you if there are any questions. 
+
+## Provide information needed for launching the group
+After approval, DIF staff will contact you requesting the final information needed to set up the group. Fill out this information and return it to DIF.
+
+## Group launch
+Your group is now ready to be launched. DIF staff will coordinate with you as needed.


### PR DESCRIPTION
These steps provide general context related to #35, describing the overall process for proposing and starting a group. This will need to be revised over time to reference additional details. as we work through our documentation backlog.

As such, this is not perfect at the moment; it's a starting point baseline.

After #35 is merged, I'll update this to link to the appropriate section