### PR TITLE
Add details to the Work Item approval process

### DIFF
--- a/work-item-lifecycle.md
+++ b/work-item-lifecycle.md
@@ -82,7 +82,7 @@ This includes:
     - In the tagged location, ensure the spec's version and specification status are up to date. 
 	- Title: Presentation Exchange v1.0.0
 	- Specification Status: DIF Ratified Specification
-4. The WG Chair may then requests SC approval.
+4. The WG Chair requests SC approval.
 
 ### 7.4. **Final Approval**.
 Upon a Draft Deliverable reaching Working Group Approved status, the Executive

--- a/work-item-lifecycle.md
+++ b/work-item-lifecycle.md
@@ -73,7 +73,7 @@ Group Approved” status.
    Template](#Acknowledgement-Template)` section below. If the WG chairs and
    membership cannot come to agreement about specific acknowledgements, this can
    be escalated to the Technical Steering Committee by either party.
-3. For Steering Committee Approval, the approved version should be placed at a 
+3. Before Steering Committee Approval, the approved version should be placed at a 
 **permanent link** tracked on DIF’s spec-tracking github repo. [See Presentation 
 Exchange v1.0.0 for an example](https://identity.foundation/presentation-exchange/spec/v1.0.0/). 
 This includes:
@@ -82,7 +82,7 @@ This includes:
     - In the tagged location, ensure the spec's version and specification status are up to date. 
 	- Title: Presentation Exchange v1.0.0
 	- Specification Status: DIF Ratified Specification
-4. The WG Chair then requests SC approval.
+4. The WG Chair may then requests SC approval.
 
 ### 7.4. **Final Approval**.
 Upon a Draft Deliverable reaching Working Group Approved status, the Executive

--- a/work-item-lifecycle.md
+++ b/work-item-lifecycle.md
@@ -73,13 +73,8 @@ Group Approved” status.
    Template](#Acknowledgement-Template)` section below. If the WG chairs and
    membership cannot come to agreement about specific acknowledgements, this can
    be escalated to the Technical Steering Committee by either party.
-3. Approved drafts should be put at a **permanent link** tracked on DIF's 
-   [spec-tracking
-   repo](https://github.com/decentralized-identity/specs/blob/master/README.md)
-   github. See the entry for [Presentation
-   Exchange](https://identity.foundation/presentation-exchange) for an example
-   of how to publish 1 or more "ratified versions" in addition to an ongoing
-   "current draft".
+3. The WG Chair then requests SC approval.
+
 
 ### 7.4. **Final Approval**.
 Upon a Draft Deliverable reaching Working Group Approved status, the Executive
@@ -94,14 +89,26 @@ Deliverable.”
    proceed to step 7.6 or only to step 7.5
 
 ### 7.5. **Publication and Submission**.
-Upon the designation of a Draft Deliverable as an Approved Deliverable, the
-Executive Director will publish the Approved Deliverable in a manner agreed upon
-by the Working Group Participants (i.e., Project Participant only location,
-publicly available location, Project maintained website, Project member website,
-etc.). The publication of an Approved Deliverable in a publicly accessible
-manner must include the terms under which the Approved Deliverable and/or source
-code is being made available under, as set forth in the applicable Working Group
-Charter.
+After Steering Committee Approval, the approved version should be placed at a 
+**permanent link** tracked on DIF’s spec-tracking github repo. [See Presentation 
+Exchange v1.0.0 for an example](https://identity.foundation/presentation-exchange/spec/v1.0.0/). 
+This includes:
+1. Copy the spec to a tagged folder in the repo
+	- For Presentation Exchange v1.0.0, spec.md is copied to the subfolder v1.0.0/
+2. In the tagged location, ensure the spec's version and specification status are
+3. up to date. 
+	- Title: Presentation Exchange v1.0.0
+	- Specification Status: DIF Ratified Specification
+4. Link to the tagged version in [DIF's spec tracking repo](https://github.com/decentralized-identity/specs/blob/master/README.md)
+
+If applicable, the Executive Director will publish the Approved Deliverable 
+in a manner agreed upon by the Working Group Participants (i.e., Project 
+Participant only location, publicly available location, Project maintained website, 
+Project member website, etc.). 
+
+The publication of an Approved Deliverable in a publicly accessible manner must 
+include the terms under which the Approved Deliverable and/or source code is being 
+made available under, as set forth in the applicable Working Group Charter.
 
 ### 7.6. **Submissions to Standards Bodies**.
 No Draft Deliverable or Approved Deliverable may be submitted to another

--- a/work-item-lifecycle.md
+++ b/work-item-lifecycle.md
@@ -77,11 +77,14 @@ Group Approved” status.
 **permanent link** tracked on DIF’s spec-tracking github repo. [See Presentation 
 Exchange v1.0.0 for an example](https://identity.foundation/presentation-exchange/spec/v1.0.0/). 
 This includes:
-    - Copy the spec to a tagged folder in the repo
-	- For Presentation Exchange v1.0.0, spec.md is copied to the subfolder v1.0.0/
-    - In the tagged location, ensure the spec's version and specification status are up to date. 
-	- Title: Presentation Exchange v1.0.0
-	- Specification Status: DIF Ratified Specification
+    - Create a subfolder under the `spec` folder named `version_number`
+    	- For Presentation Exchange v1.0.0, that results in `spec/v1.0.0/`
+    - Copy the spec.md file to the newly-created subfolder
+	- For Presentation Exchange v1.0.0, `spec/spec.md` was copied to `spec/v1.0.0/spec.md`
+    - In the copied version, ensure the spec's version and specification status are up to date.
+        - In the file `spec/v1.0.0/spec.md`, the following updates were made:
+	    - Title: Presentation Exchange v1.0.0
+	    - Specification Status: DIF Ratified Specification
 4. The WG Chair requests SC approval.
 
 ### 7.4. **Final Approval**.

--- a/work-item-lifecycle.md
+++ b/work-item-lifecycle.md
@@ -77,15 +77,16 @@ Group Approved” status.
 **permanent link** tracked on DIF’s spec-tracking github repo. [See Presentation 
 Exchange v1.0.0 for an example](https://identity.foundation/presentation-exchange/spec/v1.0.0/). 
 This includes:
-    - Create a subfolder under the `spec` folder named `version_number`
+    - In the spec repo, create a subfolder under the `spec` folder named `version_number`
     	- For Presentation Exchange v1.0.0, that results in `spec/v1.0.0/`
-    - Copy the spec.md file to the newly-created subfolder
+    - Copy the WG approved `spec.md` file to the newly-created subfolder
 	- For Presentation Exchange v1.0.0, `spec/spec.md` was copied to `spec/v1.0.0/spec.md`
     - In the copied version, ensure the spec's version and specification status are up to date.
         - In the file `spec/v1.0.0/spec.md`, the following updates were made:
 	    - Title: Presentation Exchange v1.0.0
 	    - Specification Status: DIF Ratified Specification
 4. The WG Chair requests SC approval.
+
 
 ### 7.4. **Final Approval**.
 Upon a Draft Deliverable reaching Working Group Approved status, the Executive

--- a/work-item-lifecycle.md
+++ b/work-item-lifecycle.md
@@ -73,8 +73,16 @@ Group Approved” status.
    Template](#Acknowledgement-Template)` section below. If the WG chairs and
    membership cannot come to agreement about specific acknowledgements, this can
    be escalated to the Technical Steering Committee by either party.
-3. The WG Chair then requests SC approval.
-
+3. For Steering Committee Approval, the approved version should be placed at a 
+**permanent link** tracked on DIF’s spec-tracking github repo. [See Presentation 
+Exchange v1.0.0 for an example](https://identity.foundation/presentation-exchange/spec/v1.0.0/). 
+This includes:
+    - Copy the spec to a tagged folder in the repo
+	- For Presentation Exchange v1.0.0, spec.md is copied to the subfolder v1.0.0/
+    - In the tagged location, ensure the spec's version and specification status are up to date. 
+	- Title: Presentation Exchange v1.0.0
+	- Specification Status: DIF Ratified Specification
+4. The WG Chair then requests SC approval.
 
 ### 7.4. **Final Approval**.
 Upon a Draft Deliverable reaching Working Group Approved status, the Executive
@@ -89,22 +97,13 @@ Deliverable.”
    proceed to step 7.6 or only to step 7.5
 
 ### 7.5. **Publication and Submission**.
-After Steering Committee Approval, the approved version should be placed at a 
-**permanent link** tracked on DIF’s spec-tracking github repo. [See Presentation 
-Exchange v1.0.0 for an example](https://identity.foundation/presentation-exchange/spec/v1.0.0/). 
-This includes:
-1. Copy the spec to a tagged folder in the repo
-	- For Presentation Exchange v1.0.0, spec.md is copied to the subfolder v1.0.0/
-2. In the tagged location, ensure the spec's version and specification status are
-3. up to date. 
-	- Title: Presentation Exchange v1.0.0
-	- Specification Status: DIF Ratified Specification
-4. Link to the tagged version in [DIF's spec tracking repo](https://github.com/decentralized-identity/specs/blob/master/README.md)
 
-If applicable, the Executive Director will publish the Approved Deliverable 
-in a manner agreed upon by the Working Group Participants (i.e., Project 
-Participant only location, publicly available location, Project maintained website, 
-Project member website, etc.). 
+The Executive Director will publish the Approved Deliverable in a manner agreed
+upon by the Working Group Participants (i.e., Project Participant only location,
+publicly available location, Project maintained website, Project member website,
+etc.). 
+
+Publicly-available specifications will be added to [DIF's spec tracking repo](https://github.com/decentralized-identity/specs/blob/master/README.md)
 
 The publication of an Approved Deliverable in a publicly accessible manner must 
 include the terms under which the Approved Deliverable and/or source code is being 


### PR DESCRIPTION
In general, I think we haven't been creating the tagged versions before SC approval. This adds details to the process, which we can now request.

The "publishing" part was confusing, possibly because we _only_ create public specs. I think it's reasonable to say after SC approval, the ED will ensure it's published. Since we only publish publicly, that involves adding it to the spec tracking repo. Note that I effectively moved that step from the pre-submission to post-submission. I think it makes more sense that way