### PR TITLE
Add documentation for DIF's developer advocate and ambassador programs

### DIFF
--- a/Org documents/jobs/volunteer.md
+++ b/Org documents/jobs/volunteer.md
@@ -1,0 +1,61 @@
+# DIF Volunteer Programs
+
+DIF volunteer programs are essential for decentralized identity advocacy and ecosystem growth. 
+
+# **Developer Advocate**
+
+DIF Developer Advocates are vital for fostering a vibrant and informed DIF community. This voluntary role is flexible and collaboratively defined by the DIF team and the advocate at the outset. A DIF Developer Advocate's role may include:
+
+* **Community Onboarding**: Assisting newcomers in integrating into the DIF community and understanding how to actively participate.
+* **Working Group Support**: Contributing to the processes and continuous improvement of DIF working groups.
+* **Event Support**: Supercharge DIF’s presence at events, such as DIF Hackathons. Help with knowledge sharing, judging, and answering questions.
+* **Education and Outreach**: Conducting webinars and other educational sessions to disseminate knowledge and skills related to decentralized identity.
+* **Documentation**: Creating and or maintaining community documentation on decentralized identity
+    * DIDComm book is a good example, target audience is non-technical as well as technical
+* **Event Representation**: Representing DIF at various events, advocating for decentralized identity solutions, and building connections with stakeholders.
+
+# **DIF Ambassador**
+
+A DIF Ambassador us a voluntary role whose purpose is to:
+
+* **Raise Awareness**: Increase understanding and awareness of decentralized identity technologies among businesses and the general public.
+* **Encourage Adoption**: Advocate for the adoption of decentralized identity solutions by presenting real-world use cases and benefits.
+
+The responsibilities and scope of a DIF Ambassador is flexible and collaboratively defined by the DIF team and the ambassador. These may include:
+
+* **Community Engagement**: Actively engage with the DIF community through online events and other channels.
+* **Content Creation**: Develop and share case studies, articles, and other content to highlight the value of decentralized identity.
+* **Feedback & Strategy**: Gather and relay feedback on decentralized identity challenges and opportunities to help shape future DIF initiatives.
+* **Event Participation**: Represent DIF at industry events, online seminars, and through partnerships with analysts.
+
+This voluntary role is crucial for driving the adoption and understanding of decentralized identity, contributing significantly to DIF's mission and goals.
+
+
+# Why Volunteer for DIF
+
+Engaging in voluntary roles as DIF Ambassadors or Developer Advocates offers numerous benefits, whether you’re just starting your career, a seasoned expert, or looking to make change. DIF will work with you to tailor the role to you and your interests, with benefits including the following:
+
+1. **Professional Development**:
+    * Gain in-depth knowledge and experience with cutting-edge decentralized identity technologies.
+    * Enhance skills in areas such as public speaking, technical writing, community management, and advocacy.
+2. **Career Advancement**:
+    * Boost your resume with experience in a leading global organization focused on innovative identity solutions that empower individuals.
+    * Open doors to new career opportunities and advancements within the tech industry and related fields.
+3. **Networking Opportunities**:
+    * Connect with industry leaders, technology experts, and like-minded members within the DIF community.
+4. **Recognition and Visibility**:
+    * Receive public acknowledgment for contributions through awards, social media shout-outs, and features on DIF platforms.
+    * Increase personal and professional visibility by representing DIF at high-profile industry events and conferences.
+    * Establish yourself as a thought leader in a cutting edge field.
+5. **Influence and Impact**:
+    * Play a pivotal role in shaping the future of decentralized identity adoption
+    * Help inform future direction of DIF based on community feedback.
+    * Contribute to meaningful projects that have the potential to revolutionize identity management and enhance digital security.
+6. **Access to Experts & Training**:
+    * Inside access to leading experts and training 
+7. **Community Contribution**:
+    * Make a positive impact by helping to build a more secure, user-centric, and inclusive digital identity ecosystem.
+    * Be part of a collaborative community that values innovation, integrity, and collective progress.
+
+Ambassadors and advocates not only contribute to the growth and success of DIF but also gain personal and professional benefits that can expand their platform and reach, and also access new opportunities.
+


### PR DESCRIPTION
DIF has had developer advocate and ambassador programs for a while, but we lacked documentation about what the program is, what sort of tasks they perform, and what the benefits are. We wanted to get this started as we've added some volunteers and want to start setting expectations going forward.

This is our (DIF core team) best effort at capturing the tribal knowledge of these programs -- we can use this as a baseline to iterate on.
 