### PR TITLE
Update chair instructions

### DIFF
--- a/chair_cheat_sheet.md
+++ b/chair_cheat_sheet.md
@@ -5,13 +5,14 @@ This page is designed as a central resource hub for DIF chairs. It will be kept 
 ### Chair Duties:
 
 The responsibilites of a DIF group chair include:
+
 - Ensuring compliance with all DIF rules applicable to the group.
 - Organizing the smooth operation of the group, scheduling and, where neccessary, cancelling meetings.
 - Driving inclusivity, setting a positive and productive tone.
 - Identifying consensus within the group, and recording decisions & further actions.
 - Developing, communicating an agenda and leading the meetings.
   - Inviting guests and publicising guest appearances (it's good form to disclosure business relations with guests in both introductions and in public advance promotion of guest appearances)
-- Attendance lists are optional, but chairs should invite new members to introduce themselves to the group.
+- Attendance lists are recommended, and chairs should invite new members to introduce themselves to the group.
 - Overseeing note-taking for the group meetings
 - Being a liaison between the group and all groups (both at DIF and externally) with which the group is coordinating.
 - Engaging with media, performing outreach, and ensuring the transparent operation of the group.
@@ -19,105 +20,106 @@ The responsibilites of a DIF group chair include:
 - Engagement with activity on GitHub, responding to PRs and Issues.
 - Ensuring conformance with the group's IPR agreements.
 
-
 ### Tools and tips for Working Group Chairs:
 
-- ### New member onboarding 
-    - Any company or individual who is interested in joining DIF to contribute MUST first sign one of the legal forms of affiliation (Associate, Contributor, Feedback Agreement) according to their status and budget. Once they finalize this document all necessary information will be forwarded to them via a welcome email, including the WG charters etc. 
-        - Associate member - paid dif member. Any company over 1000 employees can only choose this option.
-        - Contributor - non-paid dif member. Companies under 1000 employees can decided between this or Associate
-        - Feedback Agreement - only for individuals who are not employed
-    -  https://identity.foundation/join/
--  ### Joining Working Groups at DIF
-    -  Fill out the WG joining form(s) and complete the DocuSign that will be automatically sent to the registered email address - these steps must be done by someone who can legally represent the company 
-    -  Can be used for all but the SDS WG. The language of the charter in PDF format can be found on the WG's page on the website.
-        -  https://bit.ly/DIF-WG-select1
-    -  For the SDS WG use this form
-        -  https://bit.ly/DIF_WG_select_SDS
+- ### New member onboarding
+  - Any company or individual who is interested in joining DIF to contribute MUST first sign one of the legal forms of affiliation (Associate, Contributor, Feedback Agreement) according to their status and budget. Once they finalize this document all necessary information will be forwarded to them via a welcome email, including the WG charters etc.
+    - Associate member - paid dif member. Any company over 1000 employees can only choose this option.
+    - Contributor - non-paid dif member. Companies under 1000 employees can decided between this or Associate
+    - Feedback Agreement - only for individuals who are not employed
+  - https://identity.foundation/join/
+- ### Joining Working Groups at DIF
+  - Fill out the WG joining form(s) and complete the DocuSign that will be automatically sent to the registered email address - these steps must be done by someone who can legally represent the company
+  - Can be used for all but the SDS WG. The language of the charter in PDF format can be found on the WG's page on the website.
+    - https://bit.ly/DIF-WG-select1
+  - For the SDS WG use this form
+    - https://bit.ly/DIF_WG_select_SDS
 - ### Track signed WG agreements
-    - This is a public, automatically-updated document used to summarize the companies that have joined specific WGs
-    - WG charters in combination with DIF membership are required for Intellectual Property Rights (IPR) protection. 
-    - http://bit.ly/dif_wg_participation |
+  - This is a public, automatically-updated document used to summarize the companies that have joined specific WGs
+  - WG charters in combination with DIF membership are required for Intellectual Property Rights (IPR) protection.
+  - http://bit.ly/dif_wg_participation |
 - ### GitHub WG teams
-    - Invite GitHub contributors to the Github team according to signed WG charter
-    - https://github.com/orgs/decentralized-identity/teams
+  - Invite GitHub contributors to the Github team according to signed WG charter
+  - https://github.com/orgs/decentralized-identity/teams
 - ### WG Training Video and Presentation
-    - **DIF Working Group Training** (all DIF members recommended to watch):
-        - [Working group training recording - June 2024](https://drive.google.com/file/d/19W8AFdhTXZ_x0mxc9g2taRVEc9hln06P/view?usp=drive_link) 
-        - [Working group training slides (June 2024)](https://drive.google.com/file/d/1CEjuQZdO8_byygJI1r3rOcz3OIr4ccDe/view?usp=drive_link)
-    - Linux Foundation General Working Group Training (optional): 
-        - [Working group training recording - Sept 2023](https://drive.google.com/file/d/1PIsF1xQ5i1NPp_RG2A39NEfh6ck95HQg/view?usp=drive_link) 
-        - [Working group training slides - Sept 2023](https://docs.google.com/presentation/d/1I0B3dQLQa51uCV3VFXHLsbzmyB_jZMl4/edit?usp=sharing&ouid=116182654223161791531&rtpof=true&sd=true)
+  - **DIF Working Group Training** (all DIF members recommended to watch):
+    - [Working group training recording - June 2024](https://drive.google.com/file/d/19W8AFdhTXZ_x0mxc9g2taRVEc9hln06P/view?usp=drive_link)
+    - [Working group training slides (June 2024)](https://drive.google.com/file/d/1CEjuQZdO8_byygJI1r3rOcz3OIr4ccDe/view?usp=drive_link)
+  - Linux Foundation General Working Group Training (optional):
+    - [Working group training recording - Sept 2023](https://drive.google.com/file/d/1PIsF1xQ5i1NPp_RG2A39NEfh6ck95HQg/view?usp=drive_link)
+    - [Working group training slides - Sept 2023](https://docs.google.com/presentation/d/1I0B3dQLQa51uCV3VFXHLsbzmyB_jZMl4/edit?usp=sharing&ouid=116182654223161791531&rtpof=true&sd=true)
 
 ### Tools and tips for Open Group Chairs:
 
 - ### Joining non-working groups
-    - DIF has a set of non-WG "Open Groups" that can be found on the website in the "groups" menu
-    - These groups can be joined without signing anything as there is no specific IPR protection
-    - http://identity.foundation/
- 
-      
+  - DIF has a set of non-WG "Open Groups" that can be found on the website in the "groups" menu
+  - These groups can be joined without signing anything as there is no specific IPR protection
+  - http://identity.foundation/
+
 ### Tools and tips for all Chairs:
 
 - ### Claim host in zoom
 - Ask ED or get access to password manager for code
-    - Claim host on both accounts
-    - This is often needed to allow screen-sharing for participants
+  - Claim host on both accounts
+  - This is often needed to allow screen-sharing for participants
 - ### Recordings
-    - A list of all DIF recordings.
-    - Recordings are broken down by group using TABS at the bottom
-    - http://bit.ly/DIF_recordings_list
+  - A list of all DIF recordings.
+  - Recordings are broken down by group using TABS at the bottom
+  - http://bit.ly/DIF_recordings_list
 - ### Send the agenda before the meeting via email/slack/discord
-    - Please share an agenda before the meeting
-    - Link to agenda can be reshared in meeting chat 
-    - Link to agenda should also be available in the calendar entry and from the DIF group webpage
+  - Use the DIF standard agenda.md file and format
+    - Use this file both for tracking both the agenda before the meeting and for taking brief notes during the meeting
+    - See https://github.com/decentralized-identity/credential-schemas/blob/main/AGENDA.md for an example
+  - Please share an agenda before the meeting
+  - Link to agenda can be reshared in meeting chat
+  - Link to agenda should also be available in the calendar entry and from the DIF group webpage
 - ### Work items (GitHub)
-    - Use DIF's website to navigate between repos by opening up the working group's sub-page.
-    - https://identity.foundation/working-groups/
+  - Use DIF's website to navigate between repos by opening up the working group's sub-page.
+  - https://identity.foundation/working-groups/
 - ### Spec writing tool
-    - DIF recommends two different tools for writing specifications: SpecUP, ReSpec 
-    - https://github.com/decentralized-identity/org/blob/master/spec-tooling-guides.md 
+  - DIF recommends two different tools for writing specifications: SpecUP, ReSpec
+  - https://github.com/decentralized-identity/org/blob/master/spec-tooling-guides.md
 - ### Mailing list(s)
-    - Join the main mailing list and find group/topic relevant mailing lists in sub-categories
-    - Please use corporate email address when joining the list. Please use full name when registering.
-    -  https://dif.groups.io/g/main 
-- ### Slack 
-    - Only for DIF members. 
-    - Fill out the form and provide mail address(es) divided by comma. You will be able to invite further colleagues from within Slack (admin approval will still be required). When signing up: Use: First Last (Company) format for display name Do not contribute to WGs unless your company has signed the appropriate WG charters (as above)
-    - https://bit.ly/DIF_slack_invite
-- ### DIF Calendar / online meetings 
-    - Shared public calendar with all DIF meetings and dial-ins 
-    - Contribution only for members that finalized the  WG charter in DocuSign (described above)
-    - http://bit.ly/dif-calendar
+  - Join the main mailing list and find group/topic relevant mailing lists in sub-categories
+  - Please use corporate email address when joining the list. Please use full name when registering.
+  - https://dif.groups.io/g/main
+- ### Slack
+  - Only for DIF members.
+  - Fill out the form and provide mail address(es) divided by comma. You will be able to invite further colleagues from within Slack (admin approval will still be required). When signing up: Use: First Last (Company) format for display name Do not contribute to WGs unless your company has signed the appropriate WG charters (as above)
+  - https://bit.ly/DIF_slack_invite
+- ### DIF Calendar / online meetings
+  - Shared public calendar with all DIF meetings and dial-ins
+  - Contribution only for members that finalized the WG charter in DocuSign (described above)
+  - http://bit.ly/dif-calendar
 - ### Brand Guidelines
-    - DIF is often represented in online/in-person settings, materials and information is collected here
-    - http://bit.ly/DIF_brand_guidelines
-- ### Presentation Template 
-    - A template to create presentations at DIF
-    -  [Template](https://docs.google.com/presentation/d/1jXF5LhBLmKsbjCfGGBFNDC_tqISmgd8-DK-ISxSQkwc/edit#slide=id.g7760498cf3_0_50)
--  ### Whimsical
-    -  A visualization tool to create graphics and flowcharts 
-        -  whimsical@identity.foundation 
-        -  Password - ask DIF operations 
-        -  [Whimsical](https://whimsical.com/DMbT3mCT74bQ3wxCKBTDbQ)
-- ### Setting up new WG 
-    - Any two DIF members can initiate a new working item or group. (further information on the linked GitHub page) 
-    - For IPR-protectable material, it is best to incubate the project within an already existing WG until it reaches a level of maturity and contributing circle. 
-    - [Life Cycle](https://github.com/decentralized-identity/org/blob/master/working-group-lifecycle.md)
-- ### New chair election/nomination 
-    - If a DIF wg chair steps down, the WG can nominate new chairs. The preferred method for electing the new chair is via consensus. If there is no consensus within the group then voting must be organized - rules for the voting process are in DIF's charter. 
-    - A chair can not replace her/himself with a colleague. A nomination must take place and the group should follow consensus/voting process. 
-    - As DIF is a place for collaboration, acknowledging work funded or done by others is a gesture to recognize the efforts behind ratified work items. Consider creating a section for acknowledgments and recognize specific grants, people, or organizations whose work is invaluable for the delivered work item. 
--  ### Updating group page 
-    - The website uses templates and content is rendered accordingly. For major changes, please reach out to operations.
-    -  __Update via github:__
-        -  Use the [templates/pages/working-groups/](https://github.com/decentralized-identity/decentralized-identity.github.io/tree/master/templates/pages/working-groups) of the DIF website repo.
-             ![](https://i.imgur.com/oA6smED.jpg)
-        -  Push the changes 
-            ![](https://i.imgur.com/3eaHrxd.png)
-        -  An action automatically renders the site based on the template changes. 
-            ![](https://i.imgur.com/M65meIn.png)
-    -  __Update offline:__
-        -  in terminal: `npm install` then `gulp watch`
-        -  implement changes on the template (only)
-        -  push the changes to GitHub
+  - DIF is often represented in online/in-person settings, materials and information is collected here
+  - http://bit.ly/DIF_brand_guidelines
+- ### Presentation Template
+  - A template to create presentations at DIF
+  - [Template](https://docs.google.com/presentation/d/1jXF5LhBLmKsbjCfGGBFNDC_tqISmgd8-DK-ISxSQkwc/edit#slide=id.g7760498cf3_0_50)
+- ### Whimsical
+  - A visualization tool to create graphics and flowcharts
+    - whimsical@identity.foundation
+    - Password - ask DIF operations
+    - [Whimsical](https://whimsical.com/DMbT3mCT74bQ3wxCKBTDbQ)
+- ### Setting up new WG
+  - Any two DIF members can initiate a new working item or group. (further information on the linked GitHub page)
+  - For IPR-protectable material, it is best to incubate the project within an already existing WG until it reaches a level of maturity and contributing circle.
+  - [Life Cycle](https://github.com/decentralized-identity/org/blob/master/working-group-lifecycle.md)
+- ### New chair election/nomination
+  - If a DIF wg chair steps down, the WG can nominate new chairs. The preferred method for electing the new chair is via consensus. If there is no consensus within the group then voting must be organized - rules for the voting process are in DIF's charter.
+  - A chair can not replace her/himself with a colleague. A nomination must take place and the group should follow consensus/voting process.
+  - As DIF is a place for collaboration, acknowledging work funded or done by others is a gesture to recognize the efforts behind ratified work items. Consider creating a section for acknowledgments and recognize specific grants, people, or organizations whose work is invaluable for the delivered work item.
+- ### Updating group page
+  - The website uses templates and content is rendered accordingly. For major changes, please reach out to operations.
+  - **Update via github:**
+    - Use the [templates/pages/working-groups/](https://github.com/decentralized-identity/decentralized-identity.github.io/tree/master/templates/pages/working-groups) of the DIF website repo.
+      ![](https://i.imgur.com/oA6smED.jpg)
+    - Push the changes
+      ![](https://i.imgur.com/3eaHrxd.png)
+    - An action automatically renders the site based on the template changes.
+      ![](https://i.imgur.com/M65meIn.png)
+  - **Update offline:**
+    - in terminal: `npm install` then `gulp watch`
+    - implement changes on the template (only)
+    - push the changes to GitHub

--- a/chair_guidelines.md
+++ b/chair_guidelines.md
@@ -1,4 +1,4 @@
-# Chairs: Best Practice Guidelines 
+# Chairs: Best Practice Guidelines
 
 This guide is intended for anyone who regularly chairs calls at DIF. Please read it carefully: it outlines considerations for chairs while facilitating meetings, as well as guidance and tools to support a productive, transparent working environment across DIF.
 
@@ -9,62 +9,70 @@ Reach out to [DIF directly](mailto:operations@identity.foundation) if you need a
 _This includes links to IPR and Membership agreements, WG charters, DIF Governance documents etc, DIF Brand guidelines and other useful resources. We recommend refreshing your memory with this more compact version of these guidelines periodically._
 
 ---
+
 ### ![](https://i.imgur.com/5WjytDD.png) **Pre-call checklist [most important]**
 
---- 
+---
 
 1. Prepare and share an Agenda for the call, ideally 24 hours in advance. Disclose any business relations between chairs and speakers/topics, if pertinent.
-2. Take notes (4-5 bullet points) to capture main topics 
-3. [WGs] Make sure everyone on the call has signed the WG charter
+2. Take notes (4-5 bullet points) to capture main topics
+3. [WGs] Record attendee names in agenda.md
+   - DIF staff will follow up to ensure everyone on the call has signed the WG charter
 4. Make sure everyone understands the IPR status
-5. Follow-up on agreed tasks 
+5. Follow-up on agreed tasks
 6. Your role, as chair, is to set and follow an agenda. Everyone should be equally represented and given a chance to speak
-7. [WGs] Plan to join TSC calls (as per TSC guidelines, 1 chair/WG minimum) 
+7. [WGs] Plan to join TSC calls (as per TSC guidelines, 1 chair/WG minimum)
+
 ---
 
 ### ![](https://i.imgur.com/7cId82q.png) Before a Call
 
 ---
 
-* Prepare and share (email, Slack, or Discord depending on group culture) an Agenda for the call, ideally 24 hours in advance
-    * This can simply be a list of discussion points
-    * It can include concrete items like GitHub pull requests (with links)
-    * Consider adding estimates of time in mins for each agenda item
-    * Invite group members to add items to the agenda 
-* Double-check the meeting time in the public [DIF calendar](http://bit.ly/dif-calendar)
-    * E.g. Daylight Saving Time affects meeting schedules differently on different continents
-* Send out a reminder about the call to any guests or work item leads who are on the agenda.
-* A template for a content presentation is available [here](https://docs.google.com/presentation/d/1jXF5LhBLmKsbjCfGGBFNDC_tqISmgd8-DK-ISxSQkwc/edit#slide=id.g7760498cf3_0_50)
-* If a call has to be cancelled or postponed for whatever reason, give people as much advance notice as possible, and:
-    * Send a message via group's preferred communication channel(s)
-    * Reach out to operations@identity.foundation to update the entry in the calendar
-    * Clearly communicate when the next meeting will happen
+- Prepare and share (email, Slack, or Discord depending on group culture) an Agenda for the call, ideally 24 hours in advance
+  - Use the DIF standard agenda.md file and format
+    - Use this file both for tracking both the agenda before the meeting and for taking brief notes during the meeting
+    - See https://github.com/decentralized-identity/credential-schemas/blob/main/AGENDA.md for an example
+  - Agenda typically includes:
+    - Time to review Github issues and pull requests
+    - List of discussion points
+    - Invite group members to add items to the agenda
+  - Consider adding estimates of time in mins for each agenda item
+- Double-check the meeting time in the public [DIF calendar](http://bit.ly/dif-calendar)
+  - E.g. Daylight Saving Time affects meeting schedules differently on different continents
+- Send out a reminder about the call to any guests or work item leads who are on the agenda.
+- A template for a content presentation is available [here](https://docs.google.com/presentation/d/1jXF5LhBLmKsbjCfGGBFNDC_tqISmgd8-DK-ISxSQkwc/edit#slide=id.g7760498cf3_0_50)
+- If a call has to be cancelled or postponed for whatever reason, give people as much advance notice as possible, and:
+  - Send a message via group's preferred communication channel(s)
+  - Reach out to operations@identity.foundation to update the entry in the calendar
+  - Clearly communicate when the next meeting will happen
 
 ---
 
-### ![](https://i.imgur.com/vx8T4qO.png) Starting the Call 
+### ![](https://i.imgur.com/vx8T4qO.png) Starting the Call
 
---- 
+---
 
-* Arrive punctually to the call, allow 2-4 minutes for people to arrive
-* Greeting people as they arrive is a great opportunity to ensure everyone’s sound is working correctly as well as make them feel welcome
-* Welcome new faces and invite them to introduce themselves
-* IPR, Membership, and Charter considerations:
-    * [WGs]
-        * Restate the IPR agreement, DIF Membership, and WG Charter considerations
-    * [OGs]
-        * Restate the OG Charter considerations
-        * Remind the participants that it is NOT an IPR-protected group
-    * Drop links in chat to these documents if there are new members or guests
-* Chairs should “claim host” in Zoom; this is needed to pause or stop the recording, eject bad-faith participants, or to enable screen-sharing for attendees. 
-    * Code for claiming host privileges is in the #tsc-channel Slack channel
-* All calls are automatically recorded to DIF’s zoom account.
-    * [WGs] If a member requests pausing the call, please inform them that since WG meetings are IPR protected the entire meeting must be on record. Suggest them to discuss their topic offline and find an alternative non WG meeting time to hear what they intend to share. If in doubt about IPR, please reach out to DIF operations.
-* Share the link to the Agenda hackmd document in the Zoom chat
-* Consider screen-sharing the Agenda document and/or minutes, to encourage assistance with note-taking, URL sharing, and/or corrections
-* Invite people again to add items onto the agenda for the call
-* An attendance list in the agenda document is not essential, but can be helpful
-* If needed, please ask the group for volunteers or support with note-taking
+- Arrive punctually to the call, allow 2-4 minutes for people to arrive
+- Greeting people as they arrive is a great opportunity to ensure everyone’s sound is working correctly as well as make them feel welcome
+- Welcome new faces and invite them to introduce themselves
+- IPR, Membership, and Charter considerations:
+  - [WGs]
+    - Restate the IPR agreement, DIF Membership, and WG Charter considerations
+    - Write down the attendee names in the "Attendees" list of the agenda.md file
+  - [OGs]
+    - Restate the OG Charter considerations
+    - Remind the participants that it is NOT an IPR-protected group
+  - Drop links in chat to these documents if there are new members or guests
+- Chairs should “claim host” in Zoom; this is needed to pause or stop the recording, eject bad-faith participants, or to enable screen-sharing for attendees.
+  - Code for claiming host privileges is in the #tsc-channel Slack channel
+- All calls are automatically recorded to DIF’s zoom account.
+  - [WGs] If a member requests pausing the call, please inform them that since WG meetings are IPR protected the entire meeting must be on record. Suggest them to discuss their topic offline and find an alternative non WG meeting time to hear what they intend to share. If in doubt about IPR, please reach out to DIF operations.
+- Share the link to the Agenda hackmd document in the Zoom chat
+- Consider screen-sharing the Agenda document and/or minutes, to encourage assistance with note-taking, URL sharing, and/or corrections
+- Invite people again to add items onto the agenda for the call
+- An attendance list in the agenda document is not essential, but can be helpful
+- If needed, please ask the group for volunteers or support with note-taking
 
 ---
 
@@ -72,19 +80,19 @@ _This includes links to IPR and Membership agreements, WG charters, DIF Governan
 
 ---
 
-* Notes are an important function of the calls and groups at DIF
-* **They allow group members to stay up-to-date even if they miss calls, and helps them decide whether and how much of the recordings to watch**
-* They provide context to the code being checked in and discussed on GitHub
-* Notes help the wider community follow progress of discussions and work items
-    * The notes also form the basis for the DIF newsletter, an important channel for communicating about our work
-* They provide a history of conversations over time, important for IPR reasons
-* Please take notes in the agenda.md file on the group’s GitHub repo
-* Most groups prefer to keep a running agenda file with the most recent meeting at the top
-* Once an agenda file fills up, hackmd will disallow live editing; to “reset” the agenda.md file, move the contents to a new file using the naming convention “agenda-202X-Y.md” as needed.
-* Where feasible, the ideal notes include all major topics discussed and the range of differing viewpoints or approaches on major topics raised during the call
-    * Full transcript of all comments is not needed, high-level bullet points are fine
-    * if transcription- or W3C-style minutes get taken, these can be put into a collapsible section using &lt;details>&lt;summary>{TITLE}&lt;/summary>{CONTENT}&lt;/details> HTML tags
-* Include relevant links where possible, including those posted in the Zoom Chat
+- Notes are an important function of the calls and groups at DIF
+- **They allow group members to stay up-to-date even if they miss calls, and helps them decide whether and how much of the recordings to watch**
+- They provide context to the code being checked in and discussed on GitHub
+- Notes help the wider community follow progress of discussions and work items
+  - The notes also form the basis for the DIF newsletter, an important channel for communicating about our work
+- They provide a history of conversations over time, important for IPR reasons
+- Please take notes in the agenda.md file on the group’s GitHub repo
+- Most groups prefer to keep a running agenda file with the most recent meeting at the top
+- Once an agenda file fills up, hackmd will disallow live editing; to “reset” the agenda.md file, move the contents to a new file using the naming convention “agenda-202X-Y.md” as needed.
+- Where feasible, the ideal notes include all major topics discussed and the range of differing viewpoints or approaches on major topics raised during the call
+  - Full transcript of all comments is not needed, high-level bullet points are fine
+  - if transcription- or W3C-style minutes get taken, these can be put into a collapsible section using &lt;details>&lt;summary>{TITLE}&lt;/summary>{CONTENT}&lt;/details> HTML tags
+- Include relevant links where possible, including those posted in the Zoom Chat
 
 ---
 
@@ -92,48 +100,50 @@ _This includes links to IPR and Membership agreements, WG charters, DIF Governan
 
 ---
 
-* Present the items as outlined on the agenda
-* Keep proceedings moving forward, be conscious of limited time
-* Maintain a professional, constructive tone within the group
-    * Remember that many listeners who never show up to calls for timezone or other reasons may be listening
-* Set an expectation for when people can comment or ask questions
-* Using a queue format, ensure that everyone can speak in turn
-    * The _raise hand_ feature of Zoom is useful to maintain a speakers’ queue 
-* Keep an eye on comments and reactions in the chat
-* If time allows, open the floor to general discussion after material is covered
-* If material on the agenda is not dealt with, make it clear where that discussion will continue: asynchronous on GitHub, Slack or simply pushed to next meeting
-* If needed, set clear, actionable steps to be taken before the next call and agree who is responsible for them
-* If all content is covered before the allocated time, feel free to end the call early and give people time back
-* End the call with a reminder of when the next call will take place
-* As host, please end the recording, and use the Zoom ‘_End Meeting for All_’ button
+- Present the items as outlined on the agenda
+- Keep proceedings moving forward, be conscious of limited time
+- Maintain a professional, constructive tone within the group
+  - Remember that many listeners who never show up to calls for timezone or other reasons may be listening
+- Set an expectation for when people can comment or ask questions
+- Using a queue format, ensure that everyone can speak in turn
+  - The _raise hand_ feature of Zoom is useful to maintain a speakers’ queue
+- Keep an eye on comments and reactions in the chat
+- If time allows, open the floor to general discussion after material is covered
+- If material on the agenda is not dealt with, make it clear where that discussion will continue: asynchronous on GitHub, Slack or simply pushed to next meeting
+- If needed, set clear, actionable steps to be taken before the next call and agree who is responsible for them
+- If all content is covered before the allocated time, feel free to end the call early and give people time back
+- End the call with a reminder of when the next call will take place
+- As host, please end the recording, and use the Zoom ‘_End Meeting for All_’ button
 
---- 
+---
 
 ### ![](https://i.imgur.com/UPywVkl.png) Post-Call follow-up
 
 ---
 
-* If someone assisted with note-taking, combine the notes from the call and review their notes
-* Paste in relevant comments and links from the Zoom chat
-* A quick scan of the notes for obvious errors and omissions
-* Spreadsheet of DIF call recordings is [here](http://bit.ly/DIF_recordings_list), divided by group
-    * Recordings should appear shortly after the call, including the text chat 
-* Record group decisions and further actions
-    * Note the person responsible for the task, double-check that they've been assigned if using github issues/PRs/discussions
-    * Setting a timeframe for the task is advisable; tagging accordingly in GH can be helpful
-    * Include links, documents, contact names etc. needed for these steps
-* It's never too early to start setting the agenda for the following week or sending out reminders about upcoming guests or special agendas.
---- 
+- If someone assisted with note-taking, combine the notes from the call and review their notes
+- Paste in relevant comments and links from the Zoom chat
+- A quick scan of the notes for obvious errors and omissions
+- Spreadsheet of DIF call recordings is [here](http://bit.ly/DIF_recordings_list), divided by group
+  - Recordings should appear shortly after the call, including the text chat
+- Record group decisions and further actions
+  - Note the person responsible for the task, double-check that they've been assigned if using github issues/PRs/discussions
+  - Setting a timeframe for the task is advisable; tagging accordingly in GH can be helpful
+  - Include links, documents, contact names etc. needed for these steps
+- It's never too early to start setting the agenda for the following week or sending out reminders about upcoming guests or special agendas.
+
+---
 
 ### ![](https://i.imgur.com/SxAB6i1.png) Asynchronous: GitHub, Slack, Discord
 
 ---
 
-* While calls are an important venue for work at DIF, plenty of work and conversations happen online via Slack, Discord, email and GitHub activity, and the same substantial-contribution/”IPR boundary” should be maintained across all channels
-* Chairs are responsible for maintaining the group mailing list & monitoring emails
-* Chairs are also expected to engage with and moderate the group work at GitHub and Slack, and also ensure compliance with the appropriate rules, IPR obligations, DIF code of conduct etc.
-    * This extends to GH Discussions as well. As Discussions are created to host implementation related conversation, non-DIF members will also post there. There is a chance that such a post could include language/idea that might directly influence or qualify as a contribution to the IPR protected work item, in this case please follow these steps: 
-        * Comment on the point, warning that it may infringe or threaten IPR. Here is a template: 
+- While calls are an important venue for work at DIF, plenty of work and conversations happen online via Slack, Discord, email and GitHub activity, and the same substantial-contribution/”IPR boundary” should be maintained across all channels
+- Chairs are responsible for maintaining the group mailing list & monitoring emails
+- Chairs are also expected to engage with and moderate the group work at GitHub and Slack, and also ensure compliance with the appropriate rules, IPR obligations, DIF code of conduct etc.
+  - This extends to GH Discussions as well. As Discussions are created to host implementation related conversation, non-DIF members will also post there. There is a chance that such a post could include language/idea that might directly influence or qualify as a contribution to the IPR protected work item, in this case please follow these steps:
+    - Comment on the point, warning that it may infringe or threaten IPR. Here is a template:
+
 ```
             This comment has been removed as it might violate the Working Group's IPR.  (Intellectual property rights)
 
@@ -149,27 +159,28 @@ _This includes links to IPR and Membership agreements, WG charters, DIF Governan
 
             If you have any questions, please feel free to get in touch with me via email or DM.
 ```
-* Remember to invite call attendees to join DIF Slack and WG channels
-    * [WGs] For IPR-protected technical working groups and work items, **all active attendees** need to be DIF members; if not, they may listen in, but please warn them that they should not contribute.
-    * [OGs] For non-IPR-protected groups, any attendee can participate fully, with the understanding that any discussion topics that become work items of IPR-protected groups will require membership (i.e. it doesn’t hurt to often invite attendees to consider membership)
-* Keep an eye on GitHub pull requests, GitHub discussions and issues - “Watch all activity” function recommended
-    * Stale PRs, threads, and entire repos should be marked as such and put explicitly on the agenda for “last call” consideration before archiving
-* Collate links to GH items as a list on the agenda for the next meeting is recommended
-* Be aware of IPR considerations, particularly for unknown or unidentifiable GitHub accounts that may not belong to members who have signed agreements at DIF
 
---- 
+- Remember to invite call attendees to join DIF Slack and WG channels
+  - [WGs] For IPR-protected technical working groups and work items, **all active attendees** need to be DIF members; if not, they may listen in, but please warn them that they should not contribute.
+  - [OGs] For non-IPR-protected groups, any attendee can participate fully, with the understanding that any discussion topics that become work items of IPR-protected groups will require membership (i.e. it doesn’t hurt to often invite attendees to consider membership)
+- Keep an eye on GitHub pull requests, GitHub discussions and issues - “Watch all activity” function recommended
+  - Stale PRs, threads, and entire repos should be marked as such and put explicitly on the agenda for “last call” consideration before archiving
+- Collate links to GH items as a list on the agenda for the next meeting is recommended
+- Be aware of IPR considerations, particularly for unknown or unidentifiable GitHub accounts that may not belong to members who have signed agreements at DIF
+
+---
 
 ### ![](https://i.imgur.com/WW7ApKf.png) Procedural Considerations
 
 ---
 
-* Chairs shall be elected by the members of the group
-    * No more than four chairs should serve at any one time. 
-    * Service shall be evaluated annually, with no maximum term.
-* Each Working Group is expected to send at least one chairperson to the monthly meetings of the Technical Steering Committee
-    * More than one chair per WG may attend, however for TSC voting, each [IPR-protected] WG has one vote only. Chairs may of course confer among themselves about their vote.
-    * Chairs are encouraged to use the #tsc-internal Slack channel to propose agenda items for the TSC wherever technical and procedural questions about chairship are a blocker to the WG’s productivity.
-* If a chair leaves their organization or their employer leaves DIF, a new Chair must be selected by consensus of the other co-chairs. The outgoing chair may not appoint a replacement unilaterally. It is up to the WG Chairs to pick a replacement chair, either by consensus or taking a vote, which should be announced and minuted as a public agenda item.
+- Chairs shall be elected by the members of the group
+  - No more than four chairs should serve at any one time.
+  - Service shall be evaluated annually, with no maximum term.
+- Each Working Group is expected to send at least one chairperson to the monthly meetings of the Technical Steering Committee
+  - More than one chair per WG may attend, however for TSC voting, each [IPR-protected] WG has one vote only. Chairs may of course confer among themselves about their vote.
+  - Chairs are encouraged to use the #tsc-internal Slack channel to propose agenda items for the TSC wherever technical and procedural questions about chairship are a blocker to the WG’s productivity.
+- If a chair leaves their organization or their employer leaves DIF, a new Chair must be selected by consensus of the other co-chairs. The outgoing chair may not appoint a replacement unilaterally. It is up to the WG Chairs to pick a replacement chair, either by consensus or taking a vote, which should be announced and minuted as a public agenda item.
 
 ---
 
@@ -177,35 +188,35 @@ _This includes links to IPR and Membership agreements, WG charters, DIF Governan
 
 ---
 
-* Maintain a respectful, constructive atmosphere on calls, but also on GitHub writing, Slack channels etc.
-* DIF has a clear, inclusive [code of conduct](https://drive.google.com/file/d/1BRxGVPOXlLmFj_CzWSLroB1fcDekehv7/view): 
+- Maintain a respectful, constructive atmosphere on calls, but also on GitHub writing, Slack channels etc.
+- DIF has a clear, inclusive [code of conduct](https://drive.google.com/file/d/1BRxGVPOXlLmFj_CzWSLroB1fcDekehv7/view):
 
-    _We should strive to always be_ **_Welcoming, Empathetic & Thoughtful_**
+  _We should strive to always be_ **_Welcoming, Empathetic & Thoughtful_**
 
-* Chairs are simply responsible for facilitating the conversation in the group, and their opinion does not hold more weight than any other member, nor should they dictate the course of conversation. 
-* Consider: has everyone on a call had a chance to speak? Have pauses and sincere calls for opinion been observed for the quieter members, the guests, and the non-native speakers to feel comfortable speaking?
-    * Attendees with no video tend to get noticed less and speak less
-* Mute anyone whose mic/background noise is creating a distraction: claim host privileges, and mute them from the participants list. 
-* Consensus and agreement in the group is optimal, but cannot always be reached
-    * Strong objections can and should be mentioned in the notes, but are not, per se, a reason to stop ongoing work
-    * It is recommended that objections drive parallelized discussions and recurring agenda items to remediate while allowing other aspects of the work to continue
-* Consider how the group can embrace, grow and diversify its membership:
-    * From the code of conduct - “_Diversity is never definitively out-of-scope or foreclosed as irrelevant to more urgent business”_.
-    * _“[At DIF] we explicitly honour diversity in age, culture, ethnicity, genotype, gender identity or expression, language, national origin, neurotype, phenotype, political beliefs, profession, race, religion, dis/ability, sexual orientation, socioeconomic status, subculture and technical ability.”_
-    * Actively seek out a variety of differing viewpoints
-    * Welcome a diversity of professional and personal backgrounds
-    * Consider DIF membership from other timezones: the regular timing of a call can be changed after a consultation with and vote by attendees
-* Problematic behavior on a call should be stopped immediately and labelled inappropriate/unhelpful/not constructive. Feel free to refer group participants to the code of conduct
-* Discriminatory, insulting language, the use of sexualized language or imagery, sexual advances, offensive stereotypes or any other conduct which could reasonably be considered inappropriate in a professional setting have no place anywhere in DIF content, channels or calls
-* The DIF code of conduct contains a step-by-step conflict resolution process as well as further resources on principles and guidance
-* Consider how to best represent the interests of the group, wider membership, decentralized identity in general and DIF itself as an organization:
-    * Discuss with DIF communication team about messaging: direct or public comms calls
-    * Writing blog articles to highlight completed work, exciting news or developments, DIF comms is happy to offer editorial support
-    * Attending and speaking at industry events
-    * Considering partnerships with other orgs that have similar goals
-    * Inviting relevant key speakers to present to the group
-    * Presenting at a meeting is not an opportunity for a sales pitch to DIF membership; discussing a product is fine as long as it illustrates or illuminates a particular problem, technical solution, regional market etc
-    * DIF Brand Guidelines for members and non-members are [here](https://www.notion.so/dif/f0b4ba442083499da6c1ffb67391bd02?v=d2aefb340cb8420f8ad7930c6a6c6ece)
+- Chairs are simply responsible for facilitating the conversation in the group, and their opinion does not hold more weight than any other member, nor should they dictate the course of conversation.
+- Consider: has everyone on a call had a chance to speak? Have pauses and sincere calls for opinion been observed for the quieter members, the guests, and the non-native speakers to feel comfortable speaking?
+  - Attendees with no video tend to get noticed less and speak less
+- Mute anyone whose mic/background noise is creating a distraction: claim host privileges, and mute them from the participants list.
+- Consensus and agreement in the group is optimal, but cannot always be reached
+  - Strong objections can and should be mentioned in the notes, but are not, per se, a reason to stop ongoing work
+  - It is recommended that objections drive parallelized discussions and recurring agenda items to remediate while allowing other aspects of the work to continue
+- Consider how the group can embrace, grow and diversify its membership:
+  - From the code of conduct - “_Diversity is never definitively out-of-scope or foreclosed as irrelevant to more urgent business”_.
+  - _“[At DIF] we explicitly honour diversity in age, culture, ethnicity, genotype, gender identity or expression, language, national origin, neurotype, phenotype, political beliefs, profession, race, religion, dis/ability, sexual orientation, socioeconomic status, subculture and technical ability.”_
+  - Actively seek out a variety of differing viewpoints
+  - Welcome a diversity of professional and personal backgrounds
+  - Consider DIF membership from other timezones: the regular timing of a call can be changed after a consultation with and vote by attendees
+- Problematic behavior on a call should be stopped immediately and labelled inappropriate/unhelpful/not constructive. Feel free to refer group participants to the code of conduct
+- Discriminatory, insulting language, the use of sexualized language or imagery, sexual advances, offensive stereotypes or any other conduct which could reasonably be considered inappropriate in a professional setting have no place anywhere in DIF content, channels or calls
+- The DIF code of conduct contains a step-by-step conflict resolution process as well as further resources on principles and guidance
+- Consider how to best represent the interests of the group, wider membership, decentralized identity in general and DIF itself as an organization:
+  - Discuss with DIF communication team about messaging: direct or public comms calls
+  - Writing blog articles to highlight completed work, exciting news or developments, DIF comms is happy to offer editorial support
+  - Attending and speaking at industry events
+  - Considering partnerships with other orgs that have similar goals
+  - Inviting relevant key speakers to present to the group
+  - Presenting at a meeting is not an opportunity for a sales pitch to DIF membership; discussing a product is fine as long as it illustrates or illuminates a particular problem, technical solution, regional market etc
+  - DIF Brand Guidelines for members and non-members are [here](https://www.notion.so/dif/f0b4ba442083499da6c1ffb67391bd02?v=d2aefb340cb8420f8ad7930c6a6c6ece)
 
 **Reach out to the DIF team directly if you need support, have any questions or concerns!**
 
@@ -213,34 +224,32 @@ _This includes links to IPR and Membership agreements, WG charters, DIF Governan
 
 The responsibilities of a DIF Working Group chair include:
 
+- Ensuring compliance with all DIF rules applicable to the group.
+- Organizing the smooth operation of the group, scheduling and, where necessary, cancelling meetings.
+- Driving inclusivity, setting a positive and productive tone.
+- Identifying consensus within the group, and recording decisions & further actions.
+- Developing, communicating an agenda and leading the meetings.
+- Attendance lists are optional, but chairs should invite new members to introduce themselves to the group.
+- Notes:
+  - Overseeing note-taking for the WG meetings
+  - Notes are used to summarize the important topics and points discussed during the meetings, a full transcript is not necessary.
+  - Notes are used by DIF for the Newsletter and for the All-hands meeting to update the broader community.
+  - Notes are useful to discover historical meetings where certain topics were discussed.
+  - Notes are often used by the wider community to follow progress on work items.
+  - Notes also archive links, files etc. from the chat to make them accessible after the meeting.
+- Being a liaison between the group and all groups (both at DIF and externally) with which the group is coordinating.
+- Engaging with media, performing outreach, and ensuring the transparent operation of the group.
+- Sharing monthly updates for the DIF newsletter to inform the community
+- Engagement with activity on GitHub, responding to PRs and Issues.
+- Ensuring conformance with DIF's and the groups IPR agreements.
+- Send at least one chairperson to the monthly Technical Steering Committee meetings.
 
-
-* Ensuring compliance with all DIF rules applicable to the group.
-* Organizing the smooth operation of the group, scheduling and, where necessary, cancelling meetings.
-* Driving inclusivity, setting a positive and productive tone.
-* Identifying consensus within the group, and recording decisions & further actions.
-* Developing, communicating an agenda and leading the meetings.
-* Attendance lists are optional, but chairs should invite new members to introduce themselves to the group.
-* Notes: 
-    * Overseeing note-taking for the WG meetings
-    * Notes are used to summarize the important topics and points discussed during the meetings, a full transcript is not necessary.
-    * Notes are used by DIF for the Newsletter and for the All-hands meeting to update the broader community.
-    * Notes are useful to discover historical meetings where certain topics were discussed.
-    * Notes are often used by the wider community to follow progress on work items.
-    * Notes also archive links, files etc. from the chat to make them accessible after the meeting.
-* Being a liaison between the group and all groups (both at DIF and externally) with which the group is coordinating.
-* Engaging with media, performing outreach, and ensuring the transparent operation of the group.
-* Sharing monthly updates for the DIF newsletter to inform the community
-* Engagement with activity on GitHub, responding to PRs and Issues.
-* Ensuring conformance with DIF's and the groups IPR agreements.
-* Send at least one chairperson to the monthly Technical Steering Committee meetings. 
-
---- 
+---
 
 ## **Appendix 2**
 
-*This document was last updated **23.11.2021***				
+\*This document was last updated **23.11.2021\***
 
-*Feel free to leave us feedback or comments on this document, we are eager to learn and improve. Not all points will apply directly to every group or call. Contact us if you have questions about this document or more generally about DIF membership and work.*
+_Feel free to leave us feedback or comments on this document, we are eager to learn and improve. Not all points will apply directly to every group or call. Contact us if you have questions about this document or more generally about DIF membership and work._
 
-*Icons designed by Smashicons from [Flaticon](https://www.flaticon.com/authors/smashicons)*
+_Icons designed by Smashicons from [Flaticon](https://www.flaticon.com/authors/smashicons)_


### PR DESCRIPTION
Updates from recent discussions:
- Clarify chairs should use the agenda.md file for agenda and high-level notes
- Recommend chairs keep attendance to that DIF core team can follow up to ensure agreements signed