### PR TITLE
clarify processes in advance of more automation

### DIFF
--- a/Org documents/processes/create_group.md
+++ b/Org documents/processes/create_group.md
@@ -1,8 +1,8 @@
 # Creating a DIF group
 
-This describes the DIF operational instructions for launch a DIF group. These steps are to be performed by DIF Core Team or appropriate TSC members.
+This describes the DIF operational instructions for launching a DIF group. These steps are to be performed by DIF Core Team or appropriate TSC members.
 
-DIF groups include:
+DIF group types include:
 
 - Working Groups (WGs)
 - Special Interest Groups (SIGs)
@@ -19,8 +19,8 @@ SIGs and UGs are collectively referred to as Open Groups (OGs)
 
 DIF core team or approved person does the following steps:
 
-1. Ratify charter
-   - [**WGs**] Create docusign for approved charter and have parties sign
+1. Memorialize charter
+   - [**WGs**] Save as PDF and store in "WG documents"
    - [**OGs**] Convert to markdown (will be placed in group’s github repo)
 2. Set up group’s landing page by using the appropriate template repo and updating appropriately. Make sure to check "Include all branches", then follow the instructions in the README.md file
    - [**OGs**] Create from [https://github.com/decentralized-identity/template-for-OGs](https://github.com/decentralized-identity/template-for-OGs)
@@ -28,16 +28,13 @@ DIF core team or approved person does the following steps:
 3. [**WGs**] Set up group’s [work item repo(s)](create_work_item.md), if needed
 4. Give github access to group chairs
    - Create team for the group and add the chair github aliases
-5. Create a calendar invite on “DIF Calendar” with a meeting (zoom) link.
+5. Set up group meetings and recordings (calendar entry, zoom room, recordings)
 6. Add group to DIF web site [Repo](https://github.com/decentralized-identity/decentralized-identity.github.io)
    - [**OGs**] The repo hosts the web site, but you still have to link to it from the DIF web site.
    - [**WGs**] Create WG page; [see WG templates](https://github.com/decentralized-identity/decentralized-identity.github.io/blob/master/templates/pages/working-groups/index.html)
-7. Set up meeting recording publishing
-8. Set up communication channels
+7. Set up communication channels
    - [**WGs**] Create slack channel and mailing list
-
-- [**UGs**, **SIGs**] Create discord channel, mailing list, or other
-
-11. Double-check that group's landing page / README is updated with all links/info
-12. Onboard chairs
-13. Announce group
+   - [**UGs**, **SIGs**] Create discord channel, mailing list, or other
+8. Double-check that group's landing page / README is updated with all links/info
+9. Onboard chairs
+10. Announce group

--- a/Org documents/processes/create_work_item.md
+++ b/Org documents/processes/create_work_item.md
@@ -8,3 +8,5 @@ Each DIF working group may have its own process around launch of work items. Onc
 - https://github.com/decentralized-identity/template-for-work-items (general purpose for work items not covered above)
 
 After instantiating the repo based on a template, follow the template's readme to continue.
+
+Finally, set up group meetings and recordings (calendar entry, zoom room, recordings)


### PR DESCRIPTION
Last year we reverse-engineered what's involved in creating a group and documented/automated pieces. This is the year we automate the rest. Documenting it for correctness before proceeding